### PR TITLE
Updated SPARQL techniques using jbrowse plugin

### DIFF
--- a/wiki/static/wiki/js/JBrowse-1.12.1/plugins/WikiData/.eslintrc
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/plugins/WikiData/.eslintrc
@@ -1,0 +1,29 @@
+{
+  "extends": "eslint-config-airbnb-es5",
+  "rules": {
+    "no-var": 0,
+    "no-console": 0,
+    "space-in-parens": ["error", "never"],
+    "object-shorthand": 0,
+    "indent": ["error", 4],
+    "max-len": ["error", 200, 4],
+    "no-unused-vars": [2, {"varsIgnorePattern": "profile"}],
+    "vars-on-top": 0,
+    "prefer-arrow-callback": 0,
+    "func-names": 0
+  },
+  "globals": {
+    "$": true,
+    "window": true,
+    "console": true,
+    "dojo": true,
+    "dijit": true,
+    "define": true,
+    "require": true,
+    "describe": true,
+    "it": true
+  },
+  "env": {
+    "browser": true
+  }
+}

--- a/wiki/static/wiki/js/JBrowse-1.12.1/plugins/WikiData/README.md
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/plugins/WikiData/README.md
@@ -1,0 +1,5 @@
+# wikidataquery
+
+A small JBrowse plugin to query wikidata
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/plugins/WikiData/js/Store/SeqFeature/Genes.js
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/plugins/WikiData/js/Store/SeqFeature/Genes.js
@@ -1,0 +1,29 @@
+define([
+    'dojo/_base/declare',
+    'dojo/_base/lang',
+    './SPARQL'
+],
+function (
+    declare,
+    lang,
+    SPARQL
+) {
+    return declare(SPARQL, {
+        _readChunk: function (query, callback) {
+            this.queryTemplate = "PREFIX wdt: <http://www.wikidata.org/prop/direct/> \
+                PREFIX wd: <http://www.wikidata.org/entity/> \
+                PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> \
+                SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq \
+                WHERE { \
+                    ?featureType wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. \
+                  OPTIONAL { \
+                        ?chr qualifier:P2249 ?refSeq. \
+                          FILTER(LANG(?description) = 'en'). \
+                    } \
+                  FILTER(?refSeq = '{ref}') ?strain wdt:P685 '{organism}'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?featureType) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) \
+                }";
+            this.inherited(arguments);
+        }
+    });
+});
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/plugins/WikiData/js/Store/SeqFeature/Operons.js
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/plugins/WikiData/js/Store/SeqFeature/Operons.js
@@ -1,0 +1,18 @@
+define([
+    'dojo/_base/declare',
+    'dojo/_base/lang',
+    './SPARQL'
+],
+function (
+    declare,
+    lang,
+    SPARQL
+) {
+    return declare(SPARQL, {
+        _readChunk: function (query, callback) {
+            this.queryTemplate = "PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '{organism}'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), \"entity/\" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix"
+            this.inherited(arguments);
+        }
+    });
+});
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/plugins/WikiData/js/Store/SeqFeature/SPARQL.js
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/plugins/WikiData/js/Store/SeqFeature/SPARQL.js
@@ -1,0 +1,95 @@
+define([
+    'dojo/_base/declare',
+    'dojo/_base/lang',
+    'dojo/_base/array',
+    'dojo/request/xhr',
+    'dojo/io-query',
+    'JBrowse/Store/SeqFeature/SPARQL',
+    'JBrowse/Store/LRUCache'
+],
+function (
+    declare,
+    lang,
+    array,
+    xhr,
+    ioQuery,
+    SPARQL,
+    LRUCache
+) {
+    return declare(SPARQL, {
+        getFeatures: function (query, featCallback, finishCallback, errorCallback) {
+            var thisB = this;
+            var cache = this.featureCache = this.featureCache || new LRUCache({
+                name: 'wikiDataFeatureCache',
+                fillCallback: dojo.hitch(this, '_readChunk'),
+                sizeFunction: function (features) {
+                    return features.length;
+                },
+                maxSize: 100000 // cache up to 100,000 BAM features
+            });
+            query.toString = function () {
+                return query.ref + ',' + query.start + ',' + query.end;
+            };
+            var chunkSize = 100000;
+
+            var s = query.start - query.start % chunkSize;
+            var e = query.end + (chunkSize - (query.end % chunkSize));
+            var chunks = [];
+
+            var chunksProcessed = 0;
+            var haveError = false;
+            for (var start = s; s < e; s += chunkSize) {
+                var chunk = { ref: query.ref, start: s, end: s + chunkSize };
+                chunk.toString = function () {
+                    return query.ref + ',' + query.start + ',' + query.end;
+                };
+                chunks.push(chunk);
+            }
+
+            array.forEach(chunks, function (c) {
+                cache.get(c, function (f, e) {
+                    if (e && !haveError)                        {errorCallback(e);}
+                    if ((haveError = haveError || e)) {
+                        return;
+                    }
+                    var feats = thisB._resultsToFeatures(f, function (feature) {
+                        if (feature.get('start') > query.end) // past end of range, can stop iterating
+                            {return;}                        else if (feature.get('end') >= query.start) // must be in range
+                            {featCallback(feature);}
+                    });
+
+                    if (++chunksProcessed == chunks.length) {
+                        finishCallback();
+                    }
+                });
+            });
+        },
+        _readChunk: function (query, callback) {
+            var thisB = this;
+            var backoff = 200;
+            var headers = {
+                'Accept': 'application/json',
+                'X-Requested-With': null
+            };
+
+            xhr.get(this.url + '?' + ioQuery.objectToQuery({ query: thisB._makeQuery(query) }), {
+                headers: headers,
+                handleAs: 'json',
+                failOk: true
+            }).then(function (o) {
+                callback(o);
+            }, function (e) {
+                setTimeout(function () {
+                    thisB._readChunk(query, callback);
+                }, query.backoff);
+
+                if (query.backoff) {
+                    query.backoff *= 2;
+                } else {
+                    query.backoff = 200;
+                }
+            });
+        }
+    });
+});
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/plugins/WikiData/js/WikiData.profile.js
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/plugins/WikiData/js/WikiData.profile.js
@@ -1,0 +1,62 @@
+function copyOnly(mid) {
+    return mid in {
+        // There are no modules right now that are copy-only. If you have some, though, just add
+        // them here like this:
+        // 'app/module': 1
+    };
+}
+
+var profile = {
+    action: 'release',
+    cssOptimize: 'comments',
+    mini: true,
+
+    basePath: '../../../src',
+    packages: [
+        {name: 'WikiData', location: '../plugins/WikiData/js' }
+    ],
+
+    layerOptimize: 'closure',
+    stripConsole: 'normal',
+    selectorEngine: 'acme',
+
+    layers: {
+        'WikiData/main': {
+            include: [
+                'WikiData'
+            ],
+            exclude: [ 'JBrowse' ]
+        }
+    },
+
+    staticHasFeatures: {
+        'dojo-trace-api': 0,
+        'dojo-log-api': 0,
+        'dojo-publish-privates': 0,
+        'dojo-sync-loader': 0,
+        'dojo-xhr-factory': 0,
+        'dojo-test-sniff': 0
+    },
+
+    resourceTags: {
+        // Files that contain test code.
+        test: function (filename, mid) {
+            return false;
+        },
+
+        // Files that should be copied as-is without being modified by the build system.
+        copyOnly: function (filename, mid) {
+            return copyOnly(mid);
+        },
+
+        // Files that are AMD modules.
+        amd: function (filename, mid) {
+            return !copyOnly(mid) && /.js$/.test(filename);
+        },
+
+        // Files that should not be copied when the “mini” compiler flag is set to true.
+        miniExclude: function (filename, mid) {
+            return !(/^WikiData/.test(mid));
+        }
+    }
+};

--- a/wiki/static/wiki/js/JBrowse-1.12.1/plugins/WikiData/js/main.js
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/plugins/WikiData/js/main.js
@@ -1,0 +1,14 @@
+define([
+    'dojo/_base/declare',
+    'JBrowse/Plugin'
+],
+function (
+    declare,
+    JBrowsePlugin
+) {
+    return declare(JBrowsePlugin, {
+        constructor: function (/*args*/) {
+            console.log('WikiData plugin starting');
+        }
+    });
+});

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_100226/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_100226/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 100226
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '100226'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 100226
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '100226'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_100226/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_100226/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1028307/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1028307/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 1028307
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '1028307'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 1028307
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '1028307'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1028307/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1028307/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_107806/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_107806/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 107806
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '107806'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 107806
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '107806'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_107806/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_107806/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1122984/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1122984/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 1122984
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '1122984'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 1122984
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '1122984'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1122984/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1122984/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1125630/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1125630/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 1125630
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '1125630'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 1125630
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '1125630'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1125630/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1125630/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1133852/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1133852/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 1133852
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '1133852'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 1133852
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '1133852'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1133852/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1133852/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_115713/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_115713/tracks.conf
@@ -1,24 +1,18 @@
+plugins+=WikiData
 
-#[trackSelector]
-#type = Faceted
-#
-#[tracks.genes_canvas_mod]
-#key = Genes
-#type = JBrowse/View/Track/CanvasFeatures
-#storeClass = JBrowse/Store/SeqFeature/SPARQL
-#urlTemplate = https://query.wikidata.org/sparql
-#disablePreflight = true
-#style.color = function(feature) { return '#5C99F3'; }
-#fmtDetailValue_Name = function(name) { return 'alert(name)'; }
-#
-#queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '115713'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
-#
-#[tracks.operons_canvas_mod]
-#key = Operons
-#type = JBrowse/View/Track/CanvasFeatures
-#storeClass = JBrowse/Store/SeqFeature/SPARQL
-#urlTemplate = https://query.wikidata.org/sparql
-#disablePreflight = true
-#style.color = function(feature) { return '#385d94';}
-#
-#queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '115713'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+[tracks.genes_canvas_mod]
+key = Genes
+type = JBrowse/View/Track/CanvasFeatures
+variables.organism = 115713
+storeClass = WikiData/Store/SeqFeature/Genes
+urlTemplate = https://query.wikidata.org/sparql
+style.color = #5C99F3
+
+
+[tracks.operons_canvas_mod]
+key = Operons
+variables.organism = 115713
+type = JBrowse/View/Track/CanvasFeatures
+urlTemplate = https://query.wikidata.org/sparql
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_115713/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_115713/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1208660/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1208660/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 1208660
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '1208660'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 1208660
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '1208660'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1208660/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_1208660/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_122586/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_122586/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 122586
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '122586'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 122586
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '122586'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_122586/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_122586/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_160488/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_160488/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 160488
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '160488'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 160488
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '160488'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_160488/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_160488/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_160490/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_160490/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 160490
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '160490'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 160490
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '160490'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_160490/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_160490/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_167539/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_167539/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
-key = SPARQL Genes Tracks.conf
+key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 167539
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#FF00AC'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '167539'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 167539
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '167539'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_167539/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_167539/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_169963/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_169963/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 169963
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '169963'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 169963
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '169963'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_169963/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_169963/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_171101/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_171101/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 171101
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '171101'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 171101
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '171101'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_171101/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_171101/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_176280/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_176280/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 176280
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '176280'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 176280
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '176280'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_176280/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_176280/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_177416/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_177416/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 177416
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '177416'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 177416
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '177416'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_177416/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_177416/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_189518/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_189518/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 189518
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '189518'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 189518
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '189518'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_189518/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_189518/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_190304/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_190304/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 190304
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '190304'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 190304
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '190304'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_190304/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_190304/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_190485/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_190485/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 190485
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '190485'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 190485
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '190485'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_190485/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_190485/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_190650/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_190650/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 190650
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '190650'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 190650
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '190650'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_190650/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_190650/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_192222/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_192222/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
-key = SPARQL Genes Tracks.conf
+key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 192222
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#FF00AC'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '192222'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 192222
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '192222'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_192222/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_192222/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_194439/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_194439/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 194439
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '194439'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 194439
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '194439'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_194439/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_194439/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_196627/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_196627/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 196627
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '196627'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 196627
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '196627'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_196627/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_196627/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_197221/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_197221/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 197221
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '197221'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 197221
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '197221'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_197221/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_197221/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_198094/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_198094/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 198094
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '198094'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 198094
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '198094'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_198094/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_198094/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_198214/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_198214/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 198214
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '198214'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 198214
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '198214'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_198214/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_198214/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_205918/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_205918/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 205918
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '205918'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 205918
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '205918'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_205918/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_205918/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_206672/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_206672/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 206672
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '206672'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 206672
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '206672'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_206672/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_206672/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_208435/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_208435/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 208435
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '208435'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 208435
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '208435'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_208435/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_208435/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_208964/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_208964/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 208964
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '208964'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 208964
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '208964'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_208964/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_208964/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_210007/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_210007/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 210007
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '210007'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 210007
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '210007'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_210007/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_210007/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_211586/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_211586/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 211586
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '211586'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 211586
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '211586'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_211586/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_211586/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_214092/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_214092/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 214092
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '214092'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 214092
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '214092'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_214092/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_214092/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_220341/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_220341/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 220341
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '220341'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 220341
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '220341'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_220341/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_220341/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_220668/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_220668/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 220668
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '220668'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 220668
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '220668'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_220668/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_220668/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_223283/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_223283/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
-key = SPARQL Genes Tracks.conf
+key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 223283
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#FF00AC'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '223283'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 223283
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '223283'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_223283/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_223283/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_223926/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_223926/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 223926
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '223926'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 223926
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '223926'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_223926/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_223926/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224308/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224308/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 224308
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '224308'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 224308
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '224308'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224308/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224308/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224324/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224324/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 224324
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '224324'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 224324
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '224324'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224324/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224324/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224326/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224326/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 224326
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '224326'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 224326
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '224326'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224326/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224326/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224911/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224911/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 224911
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '224911'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 224911
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '224911'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224911/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_224911/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_226185/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_226185/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 226185
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '226185'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 226185
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '226185'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_226185/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_226185/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_226186/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_226186/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 226186
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '226186'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 226186
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '226186'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_226186/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_226186/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_226900/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_226900/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 226900
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '226900'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 226900
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '226900'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_226900/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_226900/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_227377/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_227377/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 227377
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '227377'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 227377
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '227377'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_227377/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_227377/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_233413/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_233413/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 233413
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '233413'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 233413
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '233413'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_233413/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_233413/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_242231/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_242231/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 242231
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '242231'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 242231
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '242231'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_242231/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_242231/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243090/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243090/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 243090
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '243090'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 243090
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '243090'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243090/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243090/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243160/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243160/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 243160
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '243160'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 243160
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '243160'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243160/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243160/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243161/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243161/tracks.conf
@@ -1,0 +1,18 @@
+plugins+=WikiData
+
+[tracks.genes_canvas_mod]
+key = Genes
+type = JBrowse/View/Track/CanvasFeatures
+variables.organism = 243161
+storeClass = WikiData/Store/SeqFeature/Genes
+urlTemplate = https://query.wikidata.org/sparql
+style.color = #5C99F3
+
+
+[tracks.operons_canvas_mod]
+key = Operons
+variables.organism = 243161
+type = JBrowse/View/Track/CanvasFeatures
+urlTemplate = https://query.wikidata.org/sparql
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243161/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243161/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243230/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243230/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 243230
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '243230'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 243230
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '243230'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243230/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243230/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243231/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243231/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 243231
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '243231'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 243231
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '243231'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243231/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243231/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243274/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243274/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 243274
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '243274'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 243274
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '243274'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243274/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243274/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243275/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243275/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 243275
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '243275'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 243275
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '243275'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243275/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243275/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243277/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243277/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
-key = SPARQL Genes Tracks.conf
+key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 243277
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#FF00AC'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '243277'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 243277
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '243277'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243277/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_243277/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_246196/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_246196/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 246196
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '246196'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 246196
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '246196'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_246196/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_246196/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_251221/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_251221/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 251221
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '251221'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 251221
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '251221'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_251221/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_251221/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_257313/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_257313/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 257313
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '257313'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 257313
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '257313'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_257313/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_257313/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_260799/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_260799/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 260799
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '260799'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 260799
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '260799'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_260799/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_260799/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_264732/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_264732/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 264732
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '264732'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 264732
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '264732'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_264732/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_264732/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_265311/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_265311/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 265311
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '265311'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 265311
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '265311'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_265311/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_265311/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_266834/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_266834/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 266834
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '266834'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 266834
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '266834'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_266834/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_266834/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_269796/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_269796/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 269796
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '269796'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 269796
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '269796'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_269796/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_269796/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272560/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272560/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 272560
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '272560'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 272560
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '272560'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272560/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272560/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272561/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272561/tracks.conf
@@ -1,25 +1,18 @@
+plugins+=WikiData
 
-#[trackSelector]
-#type = Faceted
-#
-#[tracks.genes_canvas_mod]
-#key = Genes
-#type = JBrowse/View/Track/CanvasFeatures
-#storeClass = JBrowse/Store/SeqFeature/SPARQL
-#urlTemplate = https://query.wikidata.org/sparql
-#disablePreflight = true
-#style.color = function(feature) { return '#5C99F3'; }
-#
-#
-#queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '272561'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
-#
-#[tracks.operons_canvas_mod]
-#key = Operons
-#type = JBrowse/View/Track/CanvasFeatures
-#storeClass = JBrowse/Store/SeqFeature/SPARQL
-#urlTemplate = https://query.wikidata.org/sparql
-#disablePreflight = true
-#style.color = function(feature) { return '#385d94';}
-#
-#queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '272561'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
-#
+[tracks.genes_canvas_mod]
+key = Genes
+type = JBrowse/View/Track/CanvasFeatures
+variables.organism = 272561
+storeClass = WikiData/Store/SeqFeature/Genes
+urlTemplate = https://query.wikidata.org/sparql
+style.color = #5C99F3
+
+
+[tracks.operons_canvas_mod]
+key = Operons
+variables.organism = 272561
+type = JBrowse/View/Track/CanvasFeatures
+urlTemplate = https://query.wikidata.org/sparql
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272561/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272561/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272562/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272562/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 272562
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '272562'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 272562
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '272562'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272562/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272562/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272563/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272563/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 272563
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '272563'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 272563
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '272563'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272563/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272563/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272621/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272621/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 272621
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '272621'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 272621
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '272621'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272621/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272621/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272623/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272623/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 272623
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '272623'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 272623
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '272623'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272623/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272623/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272624/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272624/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 272624
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '272624'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 272624
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '272624'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272624/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272624/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272631/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272631/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 272631
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '272631'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 272631
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '272631'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272631/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272631/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272632/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272632/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 272632
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '272632'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 272632
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '272632'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272632/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272632/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272634/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272634/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 272634
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '272634'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 272634
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '272634'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272634/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272634/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272943/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272943/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 272943
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '272943'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 272943
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '272943'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272943/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272943/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272947/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272947/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 272947
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '272947'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 272947
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '272947'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272947/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_272947/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_281309/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_281309/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_281309/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_281309/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 281309
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '281309'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 281309
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '281309'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_289376/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_289376/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 289376
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '289376'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 289376
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '289376'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_289376/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_289376/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_295405/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_295405/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 295405
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '295405'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 295405
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '295405'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_295405/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_295405/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_300267/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_300267/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 300267
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '300267'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 300267
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '300267'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_300267/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_300267/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_300852/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_300852/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 300852
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '300852'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 300852
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '300852'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_300852/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_300852/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_309807/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_309807/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 309807
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '309807'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 309807
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '309807'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_309807/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_309807/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_312309/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_312309/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 312309
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '312309'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 312309
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '312309'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_312309/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_312309/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_321967/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_321967/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 321967
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '321967'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 321967
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '321967'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_321967/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_321967/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_324602/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_324602/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 324602
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '324602'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 324602
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '324602'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_324602/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_324602/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_333849/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_333849/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 333849
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '333849'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 333849
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '333849'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_333849/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_333849/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_362948/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_362948/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 362948
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '362948'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 362948
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '362948'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_362948/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_362948/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_365659/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_365659/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 365659
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '365659'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 365659
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '365659'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_365659/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_365659/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_366394/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_366394/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 366394
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '366394'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 366394
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '366394'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_366394/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_366394/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_36809/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_36809/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
-key = SPARQL Genes Tracks.conf
+key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 36809
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#FF00AC'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '36809'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 36809
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '36809'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_36809/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_36809/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_380703/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_380703/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 380703
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '380703'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 380703
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '380703'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_380703/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_380703/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_386585/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_386585/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 386585
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '386585'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 386585
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '386585'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_386585/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_386585/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_388919/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_388919/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 388919
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '388919'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 388919
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '388919'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_388919/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_388919/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_393305/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_393305/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 393305
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '393305'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 393305
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '393305'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_393305/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_393305/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_394/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_394/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 394
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '394'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 394
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '394'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_394/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_394/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_402612/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_402612/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 402612
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '402612'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 402612
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '402612'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_402612/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_402612/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_413999/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_413999/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 413999
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '413999'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 413999
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '413999'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_413999/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_413999/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_441771/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_441771/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 441771
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '441771'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 441771
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '441771'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_441771/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_441771/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_471472/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_471472/tracks.conf
@@ -1,31 +1,18 @@
+plugins+=WikiData
 
-#[trackSelector]
-#type = Faceted
-#
-#[tracks.genes_canvas_mod]
-#key = Genes
-#type = JBrowse/View/Track/CanvasFeatures
-#storeClass = JBrowse/Store/SeqFeature/SPARQL
-#urlTemplate = https://query.wikidata.org/sparql
-#disablePreflight = true
-#style.color = function(feature) { return '#5C99F3'; }
-#fmtDetailValue_Name = function(name) { return 'alert(name)'; }
-#
-#queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '471472'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
-#
-#[tracks.operons_canvas_mod]
-#key = Operons
-#type = JBrowse/View/Track/CanvasFeatures
-#storeClass = JBrowse/Store/SeqFeature/SPARQL
-#urlTemplate = https://query.wikidata.org/sparql
-#disablePreflight = true
-#style.color = function(feature) { return '#385d94';}
-#
-#queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '471472'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
-#
-#[tracks.variants_canvas_mod]
-#key = variants
-#type = JBrowse/View/Track/CanvasFeatures
-#storeClass = JBrowse/Store/SeqFeature/GFF3
-#style.color = function(feature) { return 'red'; }
-#urlTemplate = kokes.gff
+[tracks.genes_canvas_mod]
+key = Genes
+type = JBrowse/View/Track/CanvasFeatures
+variables.organism = 471472
+storeClass = WikiData/Store/SeqFeature/Genes
+urlTemplate = https://query.wikidata.org/sparql
+style.color = #5C99F3
+
+
+[tracks.operons_canvas_mod]
+key = Operons
+variables.organism = 471472
+type = JBrowse/View/Track/CanvasFeatures
+urlTemplate = https://query.wikidata.org/sparql
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_471472/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_471472/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_511145/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_511145/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 511145
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '511145'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 511145
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '511145'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_511145/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_511145/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_525284/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_525284/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 525284
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '525284'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 525284
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '525284'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_525284/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_525284/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_559292/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_559292/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 559292
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '559292'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 559292
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '559292'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_559292/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_559292/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_568707/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_568707/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 568707
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '568707'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 568707
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '568707'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_568707/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_568707/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_568814/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_568814/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 568814
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '568814'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 568814
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '568814'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_568814/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_568814/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_585056/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_585056/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 585056
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '585056'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 585056
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '585056'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_585056/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_585056/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_585057/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_585057/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 585057
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '585057'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 585057
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '585057'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_585057/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_585057/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_685038/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_685038/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 685038
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '685038'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 685038
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '685038'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_685038/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_685038/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_702459/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_702459/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 702459
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '702459'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 702459
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '702459'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_702459/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_702459/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_71421/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_71421/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 71421
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '71421'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 71421
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '71421'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_71421/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_71421/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_716541/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_716541/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 716541
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '716541'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 716541
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '716541'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_716541/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_716541/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_749927/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_749927/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 749927
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '749927'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 749927
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '749927'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_749927/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_749927/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_83332/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_83332/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 83332
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '83332'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 83332
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '83332'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_83332/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_83332/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_85962/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_85962/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 85962
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '85962'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 85962
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '85962'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_85962/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_85962/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_871585/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_871585/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 871585
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '871585'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 871585
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '871585'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_871585/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_871585/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_882/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_882/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
-key = SPARQL Genes Tracks.conf
+key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 882
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#FF00AC'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '882'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 882
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '882'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_882/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_882/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_93061/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_93061/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 93061
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '93061'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 93061
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '93061'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_93061/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_93061/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_9606/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_9606/tracks.conf
@@ -1,7 +1,18 @@
+plugins+=WikiData
+
 [tracks.genes_canvas_mod]
-key = SPARQL Genes Tracks.conf
+key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 9606
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '9606'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
+style.color = #5C99F3
+
+
+[tracks.operons_canvas_mod]
+key = Operons
+variables.organism = 9606
+type = JBrowse/View/Track/CanvasFeatures
+urlTemplate = https://query.wikidata.org/sparql
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_9606/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_9606/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_99287/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_99287/tracks.conf
@@ -1,24 +1,18 @@
-
-[trackSelector]
-type = Faceted
+plugins+=WikiData
 
 [tracks.genes_canvas_mod]
 key = Genes
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
+variables.organism = 99287
+storeClass = WikiData/Store/SeqFeature/Genes
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#5C99F3'; }
-fmtDetailValue_Name = function(name) { return 'alert(name)'; }
+style.color = #5C99F3
 
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/> PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/> SELECT ?start ?end ?uniqueID ?strand ?uri ?entrezGeneID ?name ?description ?refSeq WHERE { ?gene wdt:P279 wd:Q7187; wdt:P703 ?strain; wdt:P351 ?uniqueID; wdt:P351 ?entrezGeneID; wdt:P2393 ?name; rdfs:label ?description; wdt:P644 ?start; wdt:P645 ?end; wdt:P2548 ?wdstrand ; p:P644 ?chr. OPTIONAL {?chr qualifier:P2249 ?refSeq.} FILTER(?refSeq = "{ref}") ?strain wdt:P685 '99287'. bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand). bind(str(?gene) as ?uri). filter ( !(xsd:integer(?start) > {end} || xsd:integer(?end) < {start})) }
 
 [tracks.operons_canvas_mod]
 key = Operons
+variables.organism = 99287
 type = JBrowse/View/Track/CanvasFeatures
-storeClass = JBrowse/Store/SeqFeature/SPARQL
 urlTemplate = https://query.wikidata.org/sparql
-disablePreflight = true
-style.color = function(feature) { return '#385d94';}
-
-queryTemplate = PREFIX wdt: <http://www.wikidata.org/prop/direct/> PREFIX wd: <http://www.wikidata.org/entity/>  PREFIX qualifier: <http://www.wikidata.org/prop/qualifier/>  SELECT ?uniqueID ?description ?strand  (MIN(?gstart) AS ?start)  (MAX(?gend) AS ?end) ?uri  WHERE {  ?strain wdt:P685 '99287'. ?operon wdt:P279 wd:Q139677;  wdt:P703 ?strain;  rdfs:label ?description;  wdt:P2548 ?wdstrand;  wdt:P527 ?genes.  ?genes wdt:P644 ?gstart;  wdt:P645 ?gend.  bind( IF(?wdstrand = wd:Q22809680, '1', '-1') as ?strand).  bind(str(?operon) as ?uri)  bind( strafter( str(?operon), "entity/" ) as ?uniqueID ). }  GROUP BY ?uniqueID ?description ?strand ?uri ?prefix
+storeClass = WikiData/Store/SeqFeature/Operons
+style.color = #385d94

--- a/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_99287/tracks.conf
+++ b/wiki/static/wiki/js/JBrowse-1.12.1/sparql_data/sparql_data_99287/tracks.conf
@@ -16,3 +16,8 @@ type = JBrowse/View/Track/CanvasFeatures
 urlTemplate = https://query.wikidata.org/sparql
 storeClass = WikiData/Store/SeqFeature/Operons
 style.color = #385d94
+
+[GENERAL]
+trackSelector=Faceted
+
+


### PR DESCRIPTION
I added a small jbrowse plugin named "WikiData" that manages the querying of the SPARQL store.

It is a "subclass" of the default jbrowse SPARQL storeClass but adds a couple extra features including

* caching
* retrying in case of error
* ability to query larger chunks at a time
* only querying english results (some features were returning bengali things on the existing wikigenomes.org I noticed)

 I have tested this plugin for plain-old-jbrowse but not all of wikigenomes, so let me know if there are issues.